### PR TITLE
Fix for multibyte handling issue.

### DIFF
--- a/src/main/java/com/bazaarvoice/seo/sdk/BVUIContentServiceProvider.java
+++ b/src/main/java/com/bazaarvoice/seo/sdk/BVUIContentServiceProvider.java
@@ -118,7 +118,7 @@ public class BVUIContentServiceProvider implements BVUIContentService, Callable<
                 httpRequest.viaProxy(proxy);
             } 
            
-        	content = httpRequest.execute().returnContent().asString();
+        	content = new String(httpRequest.execute().returnContent().asBytes());
         	
         } catch (ClientProtocolException e) {
             throw new BVSdkException("ERR0012");


### PR DESCRIPTION
"httpRequest.execute().returnContent().asString()" breaks multibyte characters. Need to get data in bytes.